### PR TITLE
Support rethrowing

### DIFF
--- a/ChangeLog.md
+++ b/ChangeLog.md
@@ -1,3 +1,10 @@
+# v0.3.0.0
+
+New typeclass `MonadCatchRaw`.
+Breaking changes in the API, removed some obsolete tests.
+Improved throwing/catching logic in order to support rethrowing of exceptions.
+Adjusted tests for new API.
+
 # v0.2.1.0
 
 Added instance `(MonadUnliftIO m, MonadCatch m) => MonadUnliftIO (ErrorContextT m)`.

--- a/README.md
+++ b/README.md
@@ -38,10 +38,10 @@ Consider this IO action:
 ```haskell
 testExample :: IO ()
 testExample = do
-  Left errWithCtx <- tryAnyWithContext . runErrorContextT $ do
+  Left errWithCtx :: Either (ErrorWithContext SomeException) () <- try . runErrorContextT $
     withErrorNamespace "middle-earth" $
-      withErrorNamespace "mordor" $
-      withErrorContext "ring-carrier" ("Frodo" :: Text) $ 
+    withErrorNamespace "mordor" $
+    withErrorContext "ring-carrier" ("Frodo" :: Text) $
       throwM TestException
   putStrLn . displayException $ errWithCtx
 ```

--- a/package.yaml
+++ b/package.yaml
@@ -19,7 +19,6 @@ dependencies:
 - mtl
 - text
 - exceptions
-- safe-exceptions
 - unliftio-core
 - resourcet
 - monad-logger
@@ -41,7 +40,6 @@ tests:
     ghc-options:
     - -threaded
     - -rtsopts
-    - -with-rtsopts=-N
     dependencies:
     - error-context
     - tasty

--- a/src/Control/Error/Context.hs
+++ b/src/Control/Error/Context.hs
@@ -24,63 +24,53 @@ module Control.Error.Context
   ( MonadErrorContext(..)
   , ErrorContext(..)
   , ErrorContextT
+  , MonadCatchRaw(..)
   , runErrorContextT
   , ErrorContextKatipT(..)
   , ErrorWithContext(..)
   , errorContextualize
   , errorContextForget
+  , errorContextAsString
   , errorWithContextDump
-  , catchWithoutContext
   , catchWithContext
   , catchAnyWithContext
-  , catchAnyWithoutContext
   , ensureExceptionContext
   , tryAnyWithContext
-  , tryAnyWithoutContext
   , tryWithContext
-  , tryWithoutContext
-  ) where
+  )
+where
 
 import           Control.Error.Context.Katip
 import           Control.Error.Context.Simple
 import           Control.Error.Context.Types
 
 import           Control.Error.Context.Exception
-import           Control.Exception.Safe          (SomeException (..), catchAny)
-import           Control.Monad.Catch             (Exception (..),
-                                                  MonadCatch (..), throwM)
+import           Control.Monad.Catch            ( Exception(..)
+                                                , SomeException(..)
+                                                , MonadCatch(..)
+                                                , throwM
+                                                )
 import           Control.Monad.IO.Class
 import           Data.Monoid
 
 --------------------------------------------------------------------------------
 
 -- | Dump an error with context to stdout.
-errorWithContextDump
-  :: (Show e, MonadIO m)
-  => ErrorWithContext e
-  -> m ()
+errorWithContextDump :: (Show e, MonadIO m) => ErrorWithContext e -> m ()
 errorWithContextDump (ErrorWithContext ctx err) = do
   liftIO . putStrLn $ "Error: " <> show err
   liftIO . putStrLn . errorContextAsString $ ctx
 
 -- | Enrich an error value with an error context.
-errorContextualize
-  :: MonadErrorContext m
-  => e
-  -> m (ErrorWithContext e)
+errorContextualize :: MonadErrorContext m => e -> m (ErrorWithContext e)
 errorContextualize e = do
   ctx <- errorContextCollect
   pure $ ErrorWithContext ctx e
 
-ensureExceptionContext
-  :: (MonadCatch m, MonadErrorContext m)
-  => m a
-  -> m a
-ensureExceptionContext m =
-  catchAny m $ \ someExn ->
+ensureExceptionContext :: (MonadCatchRaw m, MonadErrorContext m) => m a -> m a
+ensureExceptionContext m = catchRaw m $ \someExn ->
   case fromException someExn :: Maybe (ErrorWithContext SomeException) of
-    Just exnWithCtx ->
-      throwM exnWithCtx
-    Nothing -> do
+    Just exnWithCtx -> throwM exnWithCtx
+    Nothing         -> do
       ctx <- errorContextCollect
       throwM $ ErrorWithContext ctx someExn

--- a/src/Control/Error/Context/Exception.hs
+++ b/src/Control/Error/Context/Exception.hs
@@ -4,132 +4,67 @@ module Control.Error.Context.Exception where
 
 import           Control.Error.Context.Types
 
-import           Control.Exception.Safe      (SomeException (..), catchJust)
+import           Control.Exception              ( SomeException(..) )
+import           Control.Monad.Catch            ( catches
+                                                , Handler(..)
+                                                , MonadThrow(..)
+                                                )
 import           Control.Monad
-import           Control.Monad.Catch         (Exception (..), MonadCatch (..))
+import           Control.Monad.Catch            ( Exception(..)
+                                                , MonadCatch(..)
+                                                )
+import           Control.Monad.IO.Class
 
--- | Like 'catch', but the handler is required to be context-aware. Is
--- also able to catch exceptions of type 'e' (without context).
-catchWithContext
-  :: (MonadCatch m, Exception e)
-  => m a
-  -> (ErrorWithContext e -> m a)
-  -> m a
-catchWithContext m handler = catchJust pre m handler
-  where pre :: Exception e => SomeException -> Maybe (ErrorWithContext e)
-        pre someExn =
-          -- First we check if the exception is of the type
-          -- 'ErrorWithContext e'. If so, provide it to the handler
-          -- directly.
-          case fromException someExn of
-            Just (ErrorWithContext ctx someExnWithoutCtx :: ErrorWithContext SomeException) ->
-              case fromException someExnWithoutCtx of
-                Just exn -> Just (ErrorWithContext ctx exn)
-                Nothing  -> Nothing
-            Nothing  ->
-              -- Then we check if the exception is of the type 'e',
-              -- (without context). In this case we convert it into an
-              -- 'ErrorWithContext e' by adding an empty context and
-              -- provide the wrapped exception with context to the
-              -- handler.
-              case fromException someExn of
-                Just exn ->
-                  Just (ErrorWithContext mempty exn)
-                Nothing ->
-                  Nothing
+import           Control.Monad.Trans
+import           Data.Typeable
 
--- | Like 'catch', but the handler is required to be context-unaware.
--- Is also able to catch exceptions with context, in which case the
--- context will be forgotten before the exception will be provided to
--- the handler.
-catchWithoutContext
-  :: forall a e m
-   . (MonadCatch m, Exception e)
-  => m a
-  -> (e -> m a)
-  -> m a
-catchWithoutContext m handler = catchJust pre m handler
-  where pre :: SomeException -> Maybe e
-        pre someExn =
-          -- First we check if the exception is of the type
-          -- 'ErrorWithContext e'. In this case we forget the context
-          -- and provide the exception without context to the handler.
-          case fromException someExn :: Maybe (ErrorWithContext SomeException) of
-            Just (ErrorWithContext _ctx someExnWithoutContext) ->
-              case fromException someExnWithoutContext :: Maybe e of
-                Just exn ->
-                  Just exn
-                Nothing ->
-                  Nothing
-            Nothing  ->
-              -- Then we check if the exception is of type 'e'. If so,
-              -- provide it to the handler directly.
-              case fromException someExn :: Maybe e of
-                Just exn ->
-                  Just exn
-                Nothing  ->
-                  Nothing
+throwWithContext
+  :: (Exception e, MonadTrans t, MonadThrow m, MonadErrorContext (t m))
+  => e
+  -> t m a
+throwWithContext exn = case cast exn :: Maybe SomeException of
+  Just (SomeException inner) -> throwUnwrappedException inner
+  Nothing                    -> throwUnwrappedException exn
+ where
+  throwUnwrappedException e = if exceptionHasContext e
+    then lift $ throwM e
+    else do
+      ctx <- errorContextCollect
+      lift $ throwM (ErrorWithContext ctx e)
+
 
 tryAnyWithContext
-  :: MonadCatch m
+  :: (MonadIO m, MonadCatchRaw m, MonadThrow m)
   => m a
   -> m (Either (ErrorWithContext SomeException) a)
-tryAnyWithContext m =
-  catchWithContext (Right `liftM` m) (return . Left)
-
-tryAnyWithoutContext
-  :: MonadCatch m
-  => m a
-  -> m (Either SomeException a)
-tryAnyWithoutContext m =
-  catchWithoutContext (Right `liftM` m) (return . Left)
+tryAnyWithContext m = catchWithContext (Right `liftM` m) (return . Left)
 
 tryWithContext
-  :: (MonadCatch m, Exception e)
+  :: (MonadIO m, MonadCatchRaw m, MonadThrow m, Exception e)
   => m a
   -> m (Either (ErrorWithContext e) a)
-tryWithContext m =
-  catchWithContext (Right `liftM` m) (return . Left)
-
-tryWithoutContext
-  :: (MonadCatch m, Exception e)
-  => m a
-  -> m (Either e a)
-tryWithoutContext m =
-  catchWithoutContext (Right `liftM` m) (return . Left)
+tryWithContext m = catchWithContext (Right `liftM` m) (return . Left)
 
 -- | Forgets the context from an enriched error.
-errorContextForget
-  :: ErrorWithContext e
-  -> e
+errorContextForget :: ErrorWithContext e -> e
 errorContextForget (ErrorWithContext _ctx e) = e
 
--- | Context aware version of 'catchAny'.
 catchAnyWithContext
-  :: MonadCatch m
+  :: (MonadIO m, MonadCatchRaw m, MonadThrow m)
   => m a
   -> (ErrorWithContext SomeException -> m a)
   -> m a
-catchAnyWithContext m handler = catchJust pre m handler
-  where pre :: SomeException -> Maybe (ErrorWithContext SomeException)
-        pre someExn =
-          case fromException someExn :: Maybe (ErrorWithContext SomeException) of
-            Just exn ->
-              Just exn
-            Nothing ->
-              Just (ErrorWithContext mempty someExn)
+catchAnyWithContext = catchWithContext
 
--- | Context aware version of 'catchAny'.
-catchAnyWithoutContext
-  :: MonadCatch m
+catchWithContext
+  :: forall a e m
+   . (MonadIO m, MonadCatchRaw m, MonadThrow m, Exception e)
   => m a
-  -> (SomeException -> m a)
+  -> (ErrorWithContext e -> m a)
   -> m a
-catchAnyWithoutContext m handler = catchJust pre m handler
-  where pre :: SomeException -> Maybe SomeException
-        pre someExn =
-          case fromException someExn :: Maybe (ErrorWithContext SomeException) of
-            Just (ErrorWithContext _ctx exnWithoutContext) ->
-              Just exnWithoutContext
-            Nothing ->
-              Just someExn
+catchWithContext m h = catchRaw m $ \(someExn :: SomeException) ->
+  case fromException someExn :: Maybe (ErrorWithContext e) of
+    Just exnWithCtx -> h exnWithCtx
+    Nothing         -> case fromException someExn :: Maybe e of
+      Just exnWithoutCtx -> h (ErrorWithContext mempty exnWithoutCtx)
+      Nothing            -> throwM someExn

--- a/src/Control/Error/Context/Simple.hs
+++ b/src/Control/Error/Context/Simple.hs
@@ -30,11 +30,11 @@ import           Data.Aeson
 
 import           Control.Error.Context.Exception
 
-import           Control.Monad.Catch            ( Exception(..)
-                                                , Handler(..)
+import           Control.Monad.Catch            ( Handler(..)
                                                 , MonadCatch(..)
                                                 , SomeException(..)
                                                 , MonadThrow
+                                                , MonadMask
                                                 , throwM
                                                 , catches
                                                 )
@@ -54,7 +54,8 @@ newtype ErrorContextT m a =
                            , Monad
                            , MonadTrans
                            , MonadState s
-                           , MonadWriter w )
+                           , MonadWriter w
+                           , MonadMask )
 
 runErrorContextT :: ErrorContextT m a -> m a
 runErrorContextT = flip runReaderT mempty . _runErrorContextT

--- a/src/Control/Error/Context/Types.hs
+++ b/src/Control/Error/Context/Types.hs
@@ -53,6 +53,7 @@ instance Functor ErrorWithContext where
 data ErrorContext =
   ErrorContext { errorContextKVs       :: HashMap Text Value
                , errorContextNamespace :: [Text] }
+  deriving (Eq)
 
 instance Monoid ErrorContext where
   mempty = ErrorContext mempty mempty

--- a/src/Control/Error/Context/Types.hs
+++ b/src/Control/Error/Context/Types.hs
@@ -22,33 +22,41 @@ Provides an API for enriching errors with contexts.
 
 module Control.Error.Context.Types
   ( ErrorContext(..)
+  , MonadCatchRaw(..)
   , ErrorWithContext(..)
   , errorContextAsString
+  , exceptionHasContext
   , MonadErrorContext(..)
-  ) where
+  )
+where
 
 import           Control.Exception
-import           Control.Monad.Catch  (MonadThrow)
+import           Control.Monad.Catch            ( MonadThrow )
 import           Data.Aeson
-import qualified Data.ByteString.Lazy as ByteString.Lazy
-import           Data.Function        ((&))
-import           Data.HashMap.Strict  (HashMap)
-import qualified Data.HashMap.Strict  as HashMap
+import qualified Data.ByteString.Lazy          as ByteString.Lazy
+import           Data.Function                  ( (&) )
+import           Data.HashMap.Strict            ( HashMap )
+import qualified Data.HashMap.Strict           as HashMap
 import           Data.Monoid
-import           Data.Text            (Text)
-import qualified Data.Text            as Text
-import qualified Data.Text.Encoding   as Text
+import           Data.Text                      ( Text )
+import qualified Data.Text                     as Text
+import qualified Data.Text.Encoding            as Text
 import           Data.Typeable
 
 -- | Boundles an error with an 'ErrorContext'.
 data ErrorWithContext e =
   ErrorWithContext ErrorContext e
+  deriving (Typeable)
 
 instance Show e => Show (ErrorWithContext e) where
   show (ErrorWithContext _ctx e) = show e
 
 instance Functor ErrorWithContext where
   fmap f (ErrorWithContext ctx e) = ErrorWithContext ctx (f e)
+
+instance Applicative ErrorWithContext where
+  pure = ErrorWithContext mempty
+  (ErrorWithContext ctx f) <*> (ErrorWithContext ctx' a) = ErrorWithContext (ctx <> ctx') (f a)
 
 data ErrorContext =
   ErrorContext { errorContextKVs       :: HashMap Text Value
@@ -62,11 +70,15 @@ instance Monoid ErrorContext where
 
 -- | An @ErrorWithContext e@ can be used as an exception.
 instance Exception e => Exception (ErrorWithContext e) where
-  toException exn = SomeException exn
+  toException (ErrorWithContext ctx exn) = SomeException (ErrorWithContext ctx (toException exn))
   fromException (SomeException someExn) =
-    case cast someExn :: Maybe (ErrorWithContext e) of
-      Just (exnWithCtx @ (ErrorWithContext _ctx _exn)) ->
-        Just exnWithCtx
+    case cast someExn :: Maybe (ErrorWithContext SomeException) of
+      Just (ErrorWithContext ctx someExnWithoutCtx) ->
+        case fromException someExnWithoutCtx :: Maybe e of
+          Just exnWithoutCtx ->
+            Just (ErrorWithContext ctx exnWithoutCtx)
+          Nothing ->
+            Nothing
       Nothing ->
         Nothing
   displayException (ErrorWithContext ctx exn) =
@@ -76,29 +88,51 @@ instance Exception e => Exception (ErrorWithContext e) where
 errorContextAsString :: ErrorContext -> String
 errorContextAsString (ErrorContext hashmap layers) =
   concat $ prettyPrintKvs ++ prettyPrintCauses
+ where
+  prettyPrintKvs =
+    hashmap
+      & HashMap.toList
+      & (map $ \(label, val) ->
+          let
+            labelS = label & Text.unpack
+            valS =
+              val
+                & encode
+                & ByteString.Lazy.toStrict
+                & Text.decodeUtf8
+                & Text.unpack
+          in
+            "           " <> labelS <> ": " <> valS <> "\n"
+        )
 
-  where prettyPrintKvs =
-          hashmap
-          & HashMap.toList
-          & (map $ \ (label, val) ->
-                     let labelS = label
-                                  & Text.unpack
-                         valS   = val
-                                  & encode
-                                  & ByteString.Lazy.toStrict
-                                  & Text.decodeUtf8
-                                  & Text.unpack
-                     in "           " <> labelS <> ": " <> valS <> "\n")
-
-        prettyPrintCauses =
-          layers
-          & reverse
-          & (map $ \ layer ->
-                     let layerS = Text.unpack layer
-                     in "  caused by: " <> layerS <> "\n")
-
+  prettyPrintCauses =
+    layers
+      & reverse
+      & (map $ \layer ->
+          let layerS = Text.unpack layer in "  caused by: " <> layerS <> "\n"
+        )
 -- | Monad type class providing contextualized errors.
 class (Monad m, MonadThrow m) => MonadErrorContext m where
   errorContextCollect :: m ErrorContext     -- ^ Return the current error context.
   withErrorContext :: ToJSON v => Text -> v -> m a -> m a
   withErrorNamespace :: Text -> m a -> m a
+
+-- exceptionHasContext :: Exception e => e -> Bool
+-- exceptionHasContext exn =
+--   case cast exn :: Maybe SomeException of
+--     Just (SomeException e) -> exceptionHasContext e
+--     Nothing -> let rep  = typeOf exn
+--                    con  = typeRepTyCon rep
+--                    con' = typeRepTyCon (typeOf (ErrorWithContext mempty ()))
+--                 in con == con'
+
+exceptionHasContext :: Exception e => e -> Bool
+exceptionHasContext exn =
+  let rep  = typeOf exn
+      con  = typeRepTyCon rep
+      con' = typeRepTyCon (typeOf (ErrorWithContext mempty ()))
+  in  con == con'
+
+class MonadCatchRaw m where
+  catchRaw :: Exception e => m a -> (e -> m a) -> m a
+

--- a/test/Control/Error/Context/Test.hs
+++ b/test/Control/Error/Context/Test.hs
@@ -7,7 +7,7 @@
 {-# LANGUAGE ScopedTypeVariables #-}
 {-# LANGUAGE TemplateHaskell     #-}
 
-module Control.Error.Context.Test (tests) where
+module Control.Error.Context.Test where
 
 import Data.Aeson
 import           Control.Error.Context
@@ -30,7 +30,7 @@ import Data.Maybe
 tests :: TestTree
 tests = testGroup "Tests" $
   [ testGroup "Simple (ErrorContextT)" (testsWithConf testConfSimple)
-  -- , testGroup "Katip (ErrorContextKatipT)" (testsWithConf testConfKatip)
+  , testGroup "Katip (ErrorContextKatipT)" (testsWithConf testConfKatip)
   , testGroup "Test Examples" testExamples
   ]
 
@@ -44,14 +44,6 @@ testsWithConf conf =
         (testContextualizeIOException conf)
     , testCase "throwM"
         (testThrow conf)
-    , testCase "catchAnyWithContext"
-        (testCatchAnyWithContext conf)
-    , testCase "catchAnyWithContext/pure"
-        (testCatchAnyWithContextPure conf)
-    , testCase "catchAnyWithoutContext"
-        (testCatchAnyWithoutContext conf)
-    , testCase "catchAnyWithoutContext/pure"
-        (testCatchAnyWithoutContextPure conf)
     , testCase "Catch context-enriched exception without context"
         (testCatchWithoutContext conf)
     , testCase "Contextualize error value"
@@ -68,10 +60,6 @@ testsWithConf conf =
         (testEnsureExceptionContext conf)
     , testCase "catch head exception"
         (testCatchHeadException conf)
-    , testCase "tryAnyWithoutContext"
-        (testTryAnyWithoutContext conf)
-    , testCase "tryAnyWithoutContext/pure"
-        (testTryAnyWithoutContextPure conf)
     , testCase "tryAnyWithContext"
         (testTryAnyWithContext conf)
     , testCase "tryAnyWithContext/pure"
@@ -80,20 +68,22 @@ testsWithConf conf =
         (testTryWithContext conf)
     , testCase "tryWithContext/pure"
         (testTryWithContextPure conf)
-    , testCase "tryWithoutContext"
-        (testTryWithoutContext conf)
-    , testCase "tryWithoutContext/pure"
-        (testTryWithoutContextPure conf)
+    , testCase "try"
+        (testTry conf)
+    , testCase "try/pure"
+        (testTryPure conf)
     , testCase "Throw and catch"
         (testThrowAndCatch conf)
     , testCase "contextKvRetrieval"
         (testContextKv conf)
     , testCase "contextKvOverwrite"
         (testContextKvOverwrite conf)
-    , testCase "testRethrowKeepsExceptionUnchangedCatchAnyWithoutCtx"
-        (testRethrowKeepsExceptionUnchangedCatchAnyWithoutCtx conf)
-    -- , testCase "testRethrowKeepsExceptionUnchangedCatchAnyWithCtx"
-    --     (testRethrowKeepsExceptionUnchangedCatchAnyWithCtx conf)
+    , testCase "catchAnyWithContextRethrow"
+        (testCatchAnyWithContextRethrow conf)
+    , testCase "catchWithContextRethrow"
+        (testCatchWithContextRethrow conf)
+    , testCase "catchRethrow"
+        (testCatchRethrow conf)
     ]
 
 data TestException = TestException deriving (Show, Eq)
@@ -101,7 +91,7 @@ data TestException = TestException deriving (Show, Eq)
 instance Exception TestException
 
 data TestConf where
-  TestConf :: forall m. (MonadIO m, MonadCatch m, MonadErrorContext m) =>
+  TestConf :: forall m. (MonadIO m, MonadCatch m, MonadCatchRaw m, MonadErrorContext m) =>
               { runStackT         :: forall a. m a -> IO a }
            -> TestConf
 
@@ -143,7 +133,7 @@ testCatchWithoutContext TestConf { .. } = do
   TestException <- runStackT $
     withErrorNamespace "A" $
     withErrorNamespace "B" $
-    catchWithoutContext (throwM TestException) $ \ (exn :: TestException) -> do
+    catch (throwM TestException) $ \ (exn :: TestException) -> do
       pure exn
   pure ()
 
@@ -176,29 +166,29 @@ testThrowAndCatch TestConf { .. } = do
   void . runStackT $
     catch (throwM TestException) $ \ TestException -> pure ()
 
-testCatchAnyWithContext :: TestConf -> Assertion
-testCatchAnyWithContext TestConf { .. } = do
-  catchAnyWithContext (runStackT (throwM TestException)) $
-    \ (ErrorWithContext _ctx someExn) -> do
-      Just TestException @=? fromException someExn
+-- testCatchAnyWithContext :: TestConf -> Assertion
+-- testCatchAnyWithContext TestConf { .. } = do
+--   catchAnyWithContext (runStackT (throwM TestException)) $
+--     \ (ErrorWithContext _ctx someExn) -> do
+--       Just TestException @=? fromException someExn
 
-testCatchAnyWithContextPure :: TestConf -> Assertion
-testCatchAnyWithContextPure TestConf { .. } = do
-  catchAnyWithContext (runStackT (throw TestException)) $
-    \ (ErrorWithContext _ctx someExn) -> do
-      Just TestException @=? fromException someExn
+-- testCatchAnyWithContextPure :: TestConf -> Assertion
+-- testCatchAnyWithContextPure TestConf { .. } = do
+--   catchAnyWithContext (runStackT (throw TestException)) $
+--     \ (ErrorWithContext _ctx someExn) -> do
+--       Just TestException @=? fromException someExn
 
-testCatchAnyWithoutContext :: TestConf -> Assertion
-testCatchAnyWithoutContext TestConf { .. } = do
-  catchAnyWithoutContext (runStackT (throwM TestException)) $
-    \ someExn -> do
-      Just TestException @=? fromException someExn
+-- testCatchAnyWithoutContext :: TestConf -> Assertion
+-- testCatchAnyWithoutContext TestConf { .. } = do
+--   catchAnyWithoutContext (runStackT (throwM TestException)) $
+--     \ someExn -> do
+--       Just TestException @=? fromException someExn
 
-testCatchAnyWithoutContextPure :: TestConf -> Assertion
-testCatchAnyWithoutContextPure TestConf { .. } = do
-  catchAnyWithoutContext (runStackT (throw TestException)) $
-    \ someExn -> do
-      Just TestException @=? fromException someExn
+-- testCatchAnyWithoutContextPure :: TestConf -> Assertion
+-- testCatchAnyWithoutContextPure TestConf { .. } = do
+--   catchAnyWithoutContext (runStackT (throw TestException)) $
+--     \ someExn -> do
+--       Just TestException @=? fromException someExn
 
 testNonContextualizedCatchWithContext :: TestConf -> Assertion
 testNonContextualizedCatchWithContext TestConf { .. } = do
@@ -224,7 +214,7 @@ testEnsureExceptionContext TestConf { .. } = do
 
 testCatchHeadException :: TestConf -> Assertion
 testCatchHeadException TestConf { .. } = do
-  Left errWithCtx <- tryAnyWithContext . runStackT $ do
+  Left errWithCtx :: Either (ErrorWithContext SomeException) () <- try . runStackT $ do
     withErrorNamespace "Here I am, calling head on an empty list!" $
       ensureExceptionContext $ seq (head []) (pure ())
   let (ErrorWithContext _ctx _exnWithoutCtx) = errWithCtx
@@ -232,59 +222,48 @@ testCatchHeadException TestConf { .. } = do
 
 testTryAnyWithContext :: TestConf -> Assertion
 testTryAnyWithContext TestConf { .. } = do
-  Left (ErrorWithContext _ctx someExn) <- tryAnyWithContext . runStackT $ do
+  Left (ErrorWithContext _ctx someExn) :: Either (ErrorWithContext SomeException) () <- try . runStackT $ do
     void $ throwM TestException
     pure ()
   Just TestException @=? fromException someExn
 
 testTryAnyWithContextPure :: TestConf -> Assertion
 testTryAnyWithContextPure TestConf { .. } = do
-  Left (ErrorWithContext _ctx someExn) <- tryAnyWithContext . runStackT $
-    seq (throw TestException) (pure ())
-  Just TestException @=? fromException someExn
-
-testTryAnyWithoutContext :: TestConf -> Assertion
-testTryAnyWithoutContext TestConf { .. } = do
-  Left someExn <- tryAnyWithoutContext . runStackT $ do
-    void $ throwM TestException
-    pure ()
-  Just TestException @=? fromException someExn
-
-testTryAnyWithoutContextPure :: TestConf -> Assertion
-testTryAnyWithoutContextPure TestConf { .. } = do
-  Left someExn <- tryAnyWithoutContext . runStackT $
-    seq (throw TestException) (pure ())
+  Left (ErrorWithContext _ctx someExn) :: Either (ErrorWithContext SomeException) () <- try . runStackT $
+    ensureExceptionContext $
+      seq (throw TestException) (pure ())
   Just TestException @=? fromException someExn
 
 testTryWithContext :: TestConf -> Assertion
 testTryWithContext TestConf { .. } = do
-  Left (ErrorWithContext _ctx exn) <- tryWithContext . runStackT $ do
+  Left (ErrorWithContext _ctx exn) :: Either (ErrorWithContext TestException) () <- try . runStackT $ do
     void $ throwM TestException
     pure ()
   TestException @=? exn
 
 testTryWithContextPure :: TestConf -> Assertion
 testTryWithContextPure TestConf { .. } = do
-  Left (ErrorWithContext _ctx exn) <- tryWithContext . runStackT $
-    seq (throw TestException) (pure ())
+  Left (ErrorWithContext _ctx exn) :: Either (ErrorWithContext TestException) () <- try . runStackT $
+    ensureExceptionContext $
+      seq (throw TestException) (pure ())
   TestException @=? exn
 
-testTryWithoutContext :: TestConf -> Assertion
-testTryWithoutContext TestConf { .. } = do
-  Left exn <- tryWithoutContext . runStackT $ do
+testTry :: TestConf -> Assertion
+testTry TestConf { .. } = do
+  Left (ErrorWithContext _ctx exn) <- try . runStackT $ do
     void $ throwM TestException
     pure ()
   TestException @=? exn
 
-testTryWithoutContextPure :: TestConf -> Assertion
-testTryWithoutContextPure TestConf { .. } = do
-  Left exn <- tryWithoutContext . runStackT $
+testTryPure :: TestConf -> Assertion
+testTryPure TestConf { .. } = do
+  Left exn <- try . runStackT $
     seq (throw TestException) (pure ())
   TestException @=? exn
 
 testContextKv :: TestConf -> Assertion
 testContextKv TestConf { .. } = do
-  Left (ErrorWithContext ctx TestException) <- tryWithContext . runStackT $
+  Left (ErrorWithContext ctx TestException) :: Either (ErrorWithContext TestException) () <- try . runStackT $
     withErrorContext "ultimate-answer" answer $
     throwM TestException
   HashMap.fromList [("ultimate-answer", toJSON answer)] @=? extractKVs ctx
@@ -294,7 +273,7 @@ testContextKv TestConf { .. } = do
 
 testContextKvOverwrite :: TestConf -> Assertion
 testContextKvOverwrite TestConf { .. } = do
-  Left (ErrorWithContext ctx TestException) <- tryWithContext . runStackT $
+  Left (ErrorWithContext ctx TestException) :: Either (ErrorWithContext TestException) () <- try . runStackT $
     withErrorContext "ultimate-answer" answer $
     withErrorContext "ultimate-answer" answer' $
     throwM TestException
@@ -308,7 +287,7 @@ testContextKvOverwrite TestConf { .. } = do
 
 testExample :: IO ()
 testExample = do
-  Left errWithCtx <- tryAnyWithContext . runErrorContextT $
+  Left errWithCtx :: Either (ErrorWithContext SomeException) () <- try . runErrorContextT $
     withErrorNamespace "middle-earth" $
     withErrorNamespace "mordor" $
     withErrorContext "ring-carrier" ("Frodo" :: Text) $
@@ -354,30 +333,38 @@ structurallyEq _proxy e e' = do
 testExceptionProxy :: Proxy TestException
 testExceptionProxy = Proxy
 
-testRethrowKeepsExceptionUnchangedCatchAnyWithCtx :: TestConf -> Assertion
-testRethrowKeepsExceptionUnchangedCatchAnyWithCtx TestConf {..} = do
+testCatchAnyWithContextRethrow :: TestConf -> Assertion
+testCatchAnyWithContextRethrow TestConf {..} = do
   let referenceExn =
         SomeException (ErrorWithContext (ErrorContext HashMap.empty ["A"]) (SomeException TestException))
   Left (finalExn :: SomeException) <- try . runStackT $
     withErrorNamespace "A" $
-    catchAnyWithContext (throwM TestException) $ \exn ->  do
-      liftIO . putStrLn . displayException $ exn
+    catchWithContext (throwM TestException) $ \ (ErrorWithContext _ctx (exn:: SomeException)) ->  do
       throwM exn
 
-  putStrLn $ displayException finalExn
   assertBool (displayRawExceptions testExceptionProxy referenceExn finalExn)
     $ structurallyEq testExceptionProxy referenceExn finalExn
 
-testRethrowKeepsExceptionUnchangedCatchAnyWithoutCtx :: TestConf -> Assertion
-testRethrowKeepsExceptionUnchangedCatchAnyWithoutCtx TestConf {..} = do
-  let referenceExn = SomeException
-        (ErrorWithContext (ErrorContext HashMap.empty ["A"])
-                          (SomeException TestException))
+testCatchWithContextRethrow :: TestConf -> Assertion
+testCatchWithContextRethrow TestConf {..} = do
+  let referenceExn =
+        SomeException (ErrorWithContext (ErrorContext HashMap.empty ["A"]) (SomeException TestException))
+  Left (finalExn :: SomeException) <- try . runStackT $
+    withErrorNamespace "A" $
+    catchWithContext (throwM TestException) $ \exn@(ErrorWithContext _ctx TestException) ->  do
+      throwM exn
+
+  assertBool (displayRawExceptions testExceptionProxy referenceExn finalExn)
+    $ structurallyEq testExceptionProxy referenceExn finalExn
+
+testCatchRethrow :: TestConf -> Assertion
+testCatchRethrow TestConf {..} = do
+  let referenceExn = SomeException (ErrorWithContext (ErrorContext HashMap.empty ["A"]) (SomeException TestException))
   Left (finalExn :: SomeException) <-
     try
     . runStackT
     $ withErrorNamespace "A"
-    $ catchAnyWithoutContext (throwM TestException) throwM
+    $ catch (throwM TestException) (\exn -> throwM (exn :: TestException))
 
   assertBool (displayRawExceptions testExceptionProxy referenceExn finalExn)
     $ structurallyEq testExceptionProxy referenceExn finalExn
@@ -386,15 +373,6 @@ displayRawExceptions
   :: (Exception e, Exception e', Exception p) => Proxy p -> e -> e' -> String
 displayRawExceptions proxy e e' =
   displayRawException proxy e <> " vs. " <> displayRawException proxy e'
-
--- testEnsureExceptionContextThrowM :: TestConf -> Assertion
--- testEnsureExceptionContextThrowM TestConf { .. } = do
---   Left (ErrorWithContext ctx exn) <- tryAnyWithContext . runStackT $ do
---     withErrorNamespace "A" $
---       ensureExceptionContext $
---         throwM Overflow
---   Just Overflow @=? fromException exn
---   ["A"] @=? errorContextNamespace ctx
 
 -- testAsyncExceptionContextEnriched :: TestConf -> Assertion
 -- testAsyncExceptionContextEnriched TestConf {..} = do
@@ -439,6 +417,10 @@ data RawException = SomeExceptionWrapper RawException
   | RealExceptionWithCtx RawException
   | forall exn. Exception exn => UnknownException exn
 
+displayRawTestException
+  :: Exception e => e -> String
+displayRawTestException = displayRawException (Proxy :: Proxy TestException)
+
 displayRawException
   :: forall e f . (Exception e, Exception f) => Proxy e -> f -> String
 displayRawException _proxy exception = go (decomposeRawException exception)
@@ -464,16 +446,6 @@ displayRawException _proxy exception = go (decomposeRawException exception)
       <|> RealExceptionWithoutCtx
       .   show
       <$> (cast exn :: Maybe e)
-
-      --   case cast exn :: Maybe (ErrorWithContext e) of
-      --   Just e -> RealExceptionWithCtx (show e)
-      --   Nothin
-      -- case cast exn :: Maybe e of
-      --   Just e  -> RealExceptionWithoutCtx (show e)
-      --   Nothing -> case cast exn :: Maybe (ErrorWithContext SomeException) of
-      --   Just (ErrorWithContext _ctx exnWithoutCtx) ->
-      --     RealExceptionWithCtx (decomposeRawException exnWithoutCtx)
-      --   Nothing -> UnknownException exn
 
   go (UnknownException        exn) = show exn
   go (RealExceptionWithCtx    exn) = "ErrorWithContext(" <> go exn <> ")"


### PR DESCRIPTION
New typeclass `MonadCatchRaw`.
Breaking changes in the API, removed some obsolete tests.
Improved throwing/catching logic in order to support rethrowing of exceptions.
Adjusted tests for new API.
